### PR TITLE
default `module_load_file` to `None` because it is not required

### DIFF
--- a/src/mllooper/models/model.py
+++ b/src/mllooper/models/model.py
@@ -99,5 +99,5 @@ class Model(SeededModule, ABC):
 
 @loads(None)
 class ModelConfig(SeededModuleConfig):
-    module_load_file: Optional[Path]
+    module_load_file: Optional[Path] = None
     device: Union[str, List[str]] = 'cpu'


### PR DESCRIPTION
fixes #5 